### PR TITLE
Create emtpy /etc directory at installation to fix issue #65

### DIFF
--- a/setup/Gow.nsi
+++ b/setup/Gow.nsi
@@ -129,6 +129,9 @@ Function Files
   ; Setup files
   SetOutPath "$INSTDIR\setup"
   File /r "${SRC_DIR}\setup\*.vbs"
+
+  ; Empty etc directory, needed for bash.exe to work
+  CreateDirectory "$INSTDIR\etc"
 FunctionEnd
 
 ; Starts the installation


### PR DESCRIPTION
Hi Brent,

Here goes! Tested locally, seems to work as intended. Bash works out of the box now.