### PR TITLE
Use %~dp0 in gow.bat

### DIFF
--- a/bin/gow.bat
+++ b/bin/gow.bat
@@ -1,0 +1,2 @@
+@echo off 
+cscript //NoLogo "%~dp0gow.vbs" %1

--- a/setup/Gow.nsi
+++ b/setup/Gow.nsi
@@ -90,17 +90,6 @@ Function Configure
 
   StrCpy $R0 "cscript //NoLogo"
   nsExec::Exec '$R0 "$INSTDIR\setup\PathSetup.vbs" --path-add "$INSTDIR\bin"'
-
-  SetOutPath $INSTDIR
-
-  ClearErrors
-  FileOpen $R1 "$INSTDIR\bin\gow.bat" w
-  IfErrors done
-  FileWrite $R1 "@echo off $\r$\n"
-  FileWrite $R1 '$R0 "$INSTDIR\bin\gow.vbs" %1'
-  FileClose $R1
-
-  done:
 FunctionEnd
 
 ; Installs all files


### PR DESCRIPTION
This way the batch file does not need to be generated by the installer and the Gow installation becomes portable/movable.
