### PR TITLE
Setup tweaks to enable easier running of Bash from Gow

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,5 @@
+export HOME=$(echo "/$USERPROFILE" | sed -e 's/\\/\//g' -e 's/://')
+if [ -e ~/.bashrc ]
+then
+  source ~/.bashrc
+fi

--- a/setup/Gow.nsi
+++ b/setup/Gow.nsi
@@ -132,6 +132,10 @@ Function Files
 
   ; Bash requires the etc directory to be present.
   CreateDirectory "$INSTDIR\etc"
+
+  ; Default Bash configuration to set user's home directory, and load user-specific settings.
+  SetOutPath "$INSTDIR"
+  File "${SRC_DIR}\.bashrc"
 FunctionEnd
 
 ; Starts the installation

--- a/setup/Gow.nsi
+++ b/setup/Gow.nsi
@@ -129,6 +129,9 @@ Function Files
   ; Setup files
   SetOutPath "$INSTDIR\setup"
   File /r "${SRC_DIR}\setup\*.vbs"
+
+  ; Bash requires the etc directory to be present.
+  CreateDirectory "$INSTDIR\etc"
 FunctionEnd
 
 ; Starts the installation


### PR DESCRIPTION
1. The etc directory has to be created to enable Bash to run; added this to the installer.
2. Also added a Bash startup script which sets the user's home directory, and runs the user-specific startup script.