### PR TITLE
FIX bash exec failure when the `etc` directory is missing

### DIFF
--- a/etc/.keep.README.md
+++ b/etc/.keep.README.md
@@ -1,0 +1,10 @@
+# .keep (README.md)
+
+This is a placeholder file which forces the version control system to track and
+store this otherwise empty directory.
+
+## Why is this needed?
+
+To function, `bash` currently requires the `etc` directory to exist within the GOW
+directory structure. Without the `etc` directory, `bash` simply closes and returns
+(see bmatzelle/gow#65, bmatzelle/gow#127, and bmatzelle/gow#180).

--- a/setup/Gow.nsi
+++ b/setup/Gow.nsi
@@ -131,7 +131,8 @@ Function Files
   File /r "${SRC_DIR}\setup\*.vbs"
 
   ; Bash requires the etc directory to be present.
-  CreateDirectory "$INSTDIR\etc"
+  SetOutPath "$INSTDIR\etc"
+  File /r "${SRC_DIR}\etc\.keep.README.md"
 
   ; Default Bash configuration to set user's home directory, and load user-specific settings.
   SetOutPath "$INSTDIR"


### PR DESCRIPTION
- add the `etc` directory (containing `.keep.README.md`)
  - note: the `.keep.README.md` file is a prompt for git to store the otherwise empty directory
- fixes bmatzelle/gow#65, bmatzelle/gow#127, and bmatzelle/gow#180

.# DISCUSSION

This commit builds upon the fix for the same problem in bmatzelle/gow@21710c65cc642bc20866db2cebf91ea67a38617 by adding the `etc` directory into the repo. This makes the repo usable when installed as portable app (eg, via [`scoop`](https://github.com./lukesampson/scoop)) without requiring extra post installation steps.
