### PR TITLE
CI workflow WIP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,4 +51,4 @@ jobs:
       uses: actions/upload-artifact@v1.0.0
       with:
         name:  Gow release
-        path:  ${{ github.workspace }}/setup/*.exe
+        path:  ${{ github.workspace }}\setup\*.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Create nsis installer
       uses: joncloud/makensis-action@v3.3
       with:
+        script-file: "/setup/Gow.nsi"
         additional-plugin-paths: ${{ github.workspace }}/NSIS_Plugins/Plugins
 
     - name: Upload artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,12 +39,13 @@ jobs:
         script-file: ${{ github.workspace }}/setup/Gow.nsi
         additional-plugin-paths: ${{ github.workspace }}/NSIS_Plugins/Plugins
         
-    - name: Show me what you got (Windows)
-      run: dir
+    - name: Show me what you got
+      run: tree /F
       if: ${{ matrix.os == 'windows-latest' }}
 
-    - name: Show me what you got (all?)
-      run: ls -la
+    - name: Show me what you got
+      run: ls
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,13 @@ jobs:
       with:
         name:  Gow release
         path:  ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
+    
+    - name: upload windows artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
+        asset_name: Gow-0.8.0-1.exe
+        asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,5 +50,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0
       with:
-        name: installsig.exe
-        path: installsig.exe
+        name:  Gow release
+        path:  ${{ github.workspace }}/setup/*.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+on: [push]
+
+jobs:
+  create_installer:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ 'windows-latest', 'ubuntu-20.04' ]
+
+    steps:
+    - uses: actions/checkout@v1
+      
+    - name: Download EnVar plugin for NSIS
+      uses: carlosperate/download-file-action@v1.0.3
+      with:
+        file-url: https://nsis.sourceforge.io/mediawiki/images/7/7f/EnVar_plugin.zip
+        file-name: envar_plugin.zip
+        location: ${{ github.workspace }}
+
+    - name: Extract EnVar plugin
+      run: 7z x -o"${{ github.workspace }}/NSIS_Plugins" "${{ github.workspace }}/envar_plugin.zip"
+
+    - name: 'Install makensis (apt)'
+      run: sudo apt update && sudo apt install -y nsis nsis-pluginapi
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
+
+    - name: 'Install makensis (homebrew)'
+      run: brew update && brew install makensis
+      if: ${{ matrix.os == 'macos-latest' }}
+
+    - name: 'Set Plugin permissions'
+      run: sudo chown -R $(whoami) /usr/share/nsis/Plugins/
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
+
+    - name: Create nsis installer
+      uses: joncloud/makensis-action@v3.3
+      with:
+        additional-plugin-paths: ${{ github.workspace }}/NSIS_Plugins/Plugins
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: installsig.exe
+        path: installsig.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,9 @@ jobs:
       run: tree .\setup\ /F
       if: ${{ matrix.os == 'windows-latest' }}
 
-    - name: Show me what you got (Linux)
-      run: ls
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
+#     - name: Show me what you got (Linux)
+#       run: ls
+#       if: ${{ matrix.os == 'ubuntu-20.04' }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0
@@ -53,12 +53,21 @@ jobs:
         name:  Gow release
         path:  ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
     
-    - name: upload windows artifact
+    - name: Upload asset to github release page
+      id: upload-release-asset
       uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
         asset_path: ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
-        asset_name: Gow-0.8.0-1.exe
+        asset_name: output_${{ steps.latest_release_info.outputs.tag_name }}.exe
         asset_content_type: application/octet-stream
+    
+#     - name: upload windows artifact
+#       uses: actions/upload-release-asset@v1
+#       env:
+#         GITHUB_TOKEN: ${{ github.token }}
+#       with:
+#         upload_url: ${{ steps.create_release.outputs.upload_url }}
+#         asset_path: ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
+#         asset_name: Gow-0.8.0-1.exe
+#         asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         
     - name: Show me what you got (Windows)
       run: dir
-      if: ${{ matrixos == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-latest' }}
 
     - name: Show me what you got (all?)
       run: ls -la

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Create nsis installer
       uses: joncloud/makensis-action@v3.3
       with:
-        script-file: "/setup/Gow.nsi"
+        script-file: ${{ github.workspace }}/setup/Gow.nsi
         additional-plugin-paths: ${{ github.workspace }}/NSIS_Plugins/Plugins
 
     - name: Upload artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,11 @@ jobs:
         script-file: ${{ github.workspace }}/setup/Gow.nsi
         additional-plugin-paths: ${{ github.workspace }}/NSIS_Plugins/Plugins
         
-    - name: Show me what you got
-      run: tree /F
+    - name: Show me what you got (Windows)
+      run: tree .\setup\ /F
       if: ${{ matrix.os == 'windows-latest' }}
 
-    - name: Show me what you got
+    - name: Show me what you got (Linux)
       run: ls
       if: ${{ matrix.os == 'ubuntu-20.04' }}
 
@@ -51,4 +51,4 @@ jobs:
       uses: actions/upload-artifact@v1.0.0
       with:
         name:  Gow release
-        path:  ${{ github.workspace }}\setup\*.exe
+        path:  ${{ github.workspace }}\setup\Gow-0.8.0-1.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,13 @@ jobs:
       with:
         script-file: ${{ github.workspace }}/setup/Gow.nsi
         additional-plugin-paths: ${{ github.workspace }}/NSIS_Plugins/Plugins
+        
+    - name: Show me what you got (Windows)
+      run: dir
+      if: ${{ matrixos == 'windows-latest' }}
+
+    - name: Show me what you got (all?)
+      run: ls -la
 
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0


### PR DESCRIPTION
Hello,

I had\have a problem, where the version of the release wasn't shown anywhere
I wanted to create an issue for this, but as I was doing so, I thought, why not fix it yourself and make a PR?

answer: because I have no idea what I'm doing.
but YOLO
NOT PRODUCTION READY

## What's the problem? ##
when trying to update this via Winget, we don't get the version number, all we get is "unknown"
![image](https://user-images.githubusercontent.com/39513660/157021159-35da5ae7-2d16-4210-ad2a-8cfe015991cd.png)

Winget get its version info from the registry
so this is way we don't see the version number in "Windows Add/Remove Programs" (appwiz.cpl)
![image](https://user-images.githubusercontent.com/39513660/157021421-1f6d3400-5349-4be4-a9fc-ea6350b6e408.png)


## Where and how GOW is doing all of the registry stuff? ##
If I look inside [setup](https://github.com/bmatzelle/gow/tree/master/setup)/Gow.nsi
we have ```   !define VERSION "0.8.0-1" ``` and after that we do have 
`WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" \
                   "DisplayVersion" "${VERSION}"`
But it doesn't seem to works.
when I look in the registry, at all 3 places I can think of:
Computer\HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\
Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall

It is nowhere to be found.
not just the versionNumber, but everything.
when looking at the PR that added the currentVersion, https://github.com/bmatzelle/gow/pull/172
another weird thing I've found.
if the version number is 0.8.0-1
why does the installer still show it as 0.8.0 (without the -1)?
![image](https://user-images.githubusercontent.com/39513660/157023099-0d6cd93d-ea41-49b2-a844-ffa56a86f44f.png)

## My theory ##
after PR 172, the .nsi file was updated, but the release page is still on 0.8.0, without this PR.
other stuff as well, like the problem where the /etc folder isn't created, even though it was fixed in this commit: https://github.com/bmatzelle/gow/commit/d21710c65cc642bc20866db2cebf91ea67a38617
so I assume that the latest build (the code itself) is not the same as the released version (0.8.0)

## How to solve this ##
I think that we need a new build based on the latest code here.
only problem, I don't know how.
I've made a new workflow file.
but it's very dumb.
it's not dynamic
and I can't get the resulting artifact to publish as a release

## What need to be done so this can be production ready? ##
in the workflow, in the artifact step:
```
 - name: Upload artifact
      uses: actions/upload-artifact@v1.0.0
      with:
        name:  Gow release
        path:  ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
```
the path should not be hard coded.
something like this ``` path:  ${{ github.workspace }}\setup\Gow*.exe ``` should be the smarter option, I just can't get it to work with wildcards.

in the upload asset step:
```
- name: Upload asset to github release page
      id: upload-release-asset
      uses: actions/upload-release-asset@v1
      with:
        upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
        asset_path: ${{ github.workspace }}\setup\Gow-0.8.0-1.exe
        asset_name: output_${{ steps.latest_release_info.outputs.tag_name }}.exe
        asset_content_type: application/octet-stream
```
again, asset_path should not be hard coded with file name.
and also, it doesn't work at all! (something about upload_url path) so, we need someone who is a bit better than me to fix it.

the two steps named: ` Show me what you got ` can be removed.